### PR TITLE
feat: add basic Apophis interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ will execute a program stored in a file using the Apophis file extensions
 Apophis also includes a `malbolge_encode(string)` function that encodes a given
 string into Malbolge code using the language's encryption algorithm.
 
+An experimental interpreter for the Apophis language itself is available via
+`run_apophis(code)`.  The interpreter understands a safe subset of Python,
+allowing variable assignments, arithmetic expressions and `print` calls.  The
+output of the program is returned as a string:
+
+```python
+import apophis
+
+result = apophis.run_apophis("x = 2\nprint(x + 1)")
+assert result == "3\n"
+```
+
 Overall, Apophis blends the syntax and capabilities of both Python and
 Malbolge, allowing for the use of traditional programming concepts alongside
 the challenge and obscurity of Malbolge's encryption algorithm.

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -1,5 +1,6 @@
 import apophis
 import malbolge
+import pytest
 
 
 def test_run_malbolge_trivial():
@@ -24,3 +25,13 @@ def test_apophis_malbolge_with_apo(tmp_path):
     file = tmp_path / "sample.apo"
     file.write_text("Q")
     assert apophis.apophis_malbolge(file) == ''
+
+
+def test_run_apophis_basic():
+    code = "x = 1\nprint(x + 2)"
+    assert apophis.run_apophis(code) == "3\n"
+
+
+def test_run_apophis_rejects_import():
+    with pytest.raises(ValueError):
+        apophis.run_apophis("import os")


### PR DESCRIPTION
## Summary
- extend Apophis with `run_apophis` to execute a safe Python subset
- document new interpreter and its usage
- test basic execution and invalid syntax handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ecd946fcc832f9b28113a2dcf2fb6