### PR TITLE
Enable hybrid Python/Malbolge execution in Apophis

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,39 @@ Future usage for the #ApophisMiningFacility and the #ApophisClassUNSCStarfleet #
 
 Apophis is an (In Development) programming language that combines the syntax of Python and the esoteric programming language Malbolge. (#GitHub Coming Soon)
 
-Apophis includes the ability to run Malbolge code using the run_malbolge(code) function. This takes a Malbolge program as a string argument and returns the output.
-   
-Additionally, Apophis has a built-in function called `apophis_malbolge()` that
-will execute a program stored in a file using the Apophis file extensions
-``.apop`` or ``.apo``.  By default a file named ``malbolge.apop`` is loaded.
+Apophis includes the ability to run Malbolge code using the `run_malbolge(code)`
+function. This takes a Malbolge program as a string argument and returns the
+output.
 
-Apophis also includes a `malbolge_encode(string)` function that encodes a given
-string into Malbolge code using the language's encryption algorithm.
+The language also supports **hybrid programs** that mix Python and Malbolge.  In
+these sources, lines beginning with ``:`` are interpreted as Python while all
+other lines are executed as Malbolge.  The outputs from both languages are
+concatenated.  Use :func:`apophis.run_apophis` to execute code stored in a
+string and :func:`apophis.run_file` for ``.apop``/``.apo`` files.
 
-An experimental interpreter for the Apophis language itself is available via
-`run_apophis(code)`.  The interpreter understands a safe subset of Python,
-allowing variable assignments, arithmetic expressions and `print` calls.  The
-output of the program is returned as a string:
+Example hybrid program executed from a string:
 
 ```python
 import apophis
 
-result = apophis.run_apophis("x = 2\nprint(x + 1)")
+code = ":print('A', end='')\n>b\n:print('B')"
+print(apophis.run_apophis(code))  # -> AsB\n
+```
+
+Hybrid sources can also be saved to ``.apop`` files and run with
+``apophis.run_file('program.apop')``.
+
+Apophis also includes a `malbolge_encode(string)` function that encodes a given
+string into Malbolge code using the language's encryption algorithm.
+
+An interpreter for a safe subset of Python is available via
+`run_python(code)`.  It allows variable assignments, arithmetic expressions and
+`print` calls.  The output of the program is returned as a string:
+
+```python
+import apophis
+
+result = apophis.run_python("x = 2\nprint(x + 1)")
 assert result == "3\n"
 ```
 
@@ -49,9 +64,9 @@ output = apophis.run_malbolge('Q')  # execute code stored in a string
 encoded = apophis.malbolge_encode('Hello!')
 ```
 
-Place an Apophis program in `malbolge.apop` and call
-`apophis.apophis_malbolge()` to run it.  The module also installs a command
-line tool so programs can be executed directly:
+Place a hybrid Apophis program in `malbolge.apop` and call
+`apophis.run_file()` to run it.  The module also installs a command line tool
+so programs can be executed directly:
 
 ```bash
 apophis path/to/program.apo

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -17,21 +17,32 @@ def test_malbolge_encode():
     assert encoded == expected
 
 
-def test_apophis_malbolge():
-    assert apophis.apophis_malbolge() == ''
+def test_run_file_default():
+    assert apophis.run_file() == ''
 
 
-def test_apophis_malbolge_with_apo(tmp_path):
+def test_run_file_with_apo(tmp_path):
     file = tmp_path / "sample.apo"
     file.write_text("Q")
-    assert apophis.apophis_malbolge(file) == ''
+    assert apophis.run_file(file) == ''
 
 
-def test_run_apophis_basic():
+def test_run_python_basic():
     code = "x = 1\nprint(x + 2)"
-    assert apophis.run_apophis(code) == "3\n"
+    assert apophis.run_python(code) == "3\n"
 
 
-def test_run_apophis_rejects_import():
+def test_run_python_rejects_import():
     with pytest.raises(ValueError):
-        apophis.run_apophis("import os")
+        apophis.run_python("import os")
+
+
+def test_run_apophis_mixed_string():
+    code = ":print('A', end='')\n>b\n:print('B', end='')"
+    assert apophis.run_apophis(code) == "AsB"
+
+
+def test_run_apophis_mixed_file(tmp_path):
+    file = tmp_path / "hybrid.apop"
+    file.write_text(":print('hi', end='')\n>b\n")
+    assert apophis.run_file(file) == "his"


### PR DESCRIPTION
## Summary
- add `run_apophis` and `run_file` pipeline so Apophis code can mix Python lines prefixed with `:` and Malbolge segments, concatenating their output
- document the new hybrid syntax and how to execute programs from strings or `.apop` files
- test mixed-language execution from strings and files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ecf1721c4832f8d1068154c94cf1a