### PR TITLE
Add interactive REPL and persistent Python state

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,16 @@ so programs can be executed directly:
 ```bash
 apophis path/to/program.apo
 ```
+
+An interactive REPL is also available for quick experiments:
+
+```python
+import apophis
+apophis.repl()
+```
+
+or from the command line:
+
+```bash
+apophis -i
+```

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -46,3 +46,26 @@ def test_run_apophis_mixed_file(tmp_path):
     file = tmp_path / "hybrid.apop"
     file.write_text(":print('hi', end='')\n>b\n")
     assert apophis.run_file(file) == "his"
+
+
+def test_run_apophis_persistent_env():
+    code = ":x = 1\n>b\n:print(x, end='')"
+    assert apophis.run_apophis(code) == "s1"
+
+
+def test_repl_persistence():
+    inputs = iter([":x = 2", ":print(x)", ""])
+
+    def fake_input(prompt=""):
+        try:
+            return next(inputs)
+        except StopIteration:
+            raise EOFError
+
+    outputs: list[str] = []
+
+    def fake_output(s: str, end: str = "\n") -> None:
+        outputs.append(s + end)
+
+    apophis.repl(input_func=fake_input, output_func=fake_output)
+    assert "".join(outputs) == "2\n"


### PR DESCRIPTION
## Summary
- allow Python snippets to share state via optional environment dictionaries
- introduce a REPL with CLI `-i` flag for interactive Apophis sessions
- document interactive usage and add tests for state persistence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ed1b1369c832fa3134bf27c5aa00b