### PR TITLE
feat: support comments in Apophis programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ print(apophis.run_apophis(code))  # -> AsB\n
 Hybrid sources can also be saved to ``.apop`` files and run with
 ``apophis.run_file('program.apop')``.
 
+Lines beginning with ``#`` are treated as comments and ignored by the
+interpreter, allowing Apophis programs to be documented without affecting
+execution.
+
 Apophis also includes a `malbolge_encode(string)` function that encodes a given
 string into Malbolge code using the language's encryption algorithm.
 

--- a/apophis.py
+++ b/apophis.py
@@ -120,7 +120,8 @@ def run_apophis(code: str, py_env: dict[str, object] | None = None) -> str:
     Parameters
     ----------
     code:
-        Hybrid Apophis source combining Python and Malbolge lines.
+        Hybrid Apophis source combining Python and Malbolge lines.  Blank lines
+        and those starting with ``#`` are treated as comments and ignored.
     py_env:
         Optional environment dictionary shared by all Python segments.
     """
@@ -132,6 +133,9 @@ def run_apophis(code: str, py_env: dict[str, object] | None = None) -> str:
     current_type: str | None = None
     buffer: list[str] = []
     for raw_line in code.splitlines():
+        stripped = raw_line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
         if raw_line.startswith(":"):
             seg_type = "py"
             line = raw_line[1:]

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -53,6 +53,11 @@ def test_run_apophis_persistent_env():
     assert apophis.run_apophis(code) == "s1"
 
 
+def test_run_apophis_comments():
+    code = "# comment\n:print('X', end='')\n# another\nQ"
+    assert apophis.run_apophis(code) == "X"
+
+
 def test_repl_persistence():
     inputs = iter([":x = 2", ":print(x)", ""])
 


### PR DESCRIPTION
## Summary
- allow `#` comment lines and blank lines in Apophis sources
- document comment usage in README
- test comment parsing in interpreter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6e6d8d98832fa3f70462f6c2f790