### PR TITLE
Add control flow to Apophis Python subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Apophis also includes a `malbolge_encode(string)` function that encodes a given
 string into Malbolge code using the language's encryption algorithm.
 
 An interpreter for a safe subset of Python is available via
-`run_python(code)`.  It allows variable assignments, arithmetic expressions and
-`print` calls.  The output of the program is returned as a string:
+`run_python(code)`.  It allows variable assignments, arithmetic expressions,
+basic control flow (``if`` statements and ``while`` loops) and ``print`` calls.
+The output of the program is returned as a string:
 
 ```python
 import apophis

--- a/apophis.py
+++ b/apophis.py
@@ -71,6 +71,11 @@ def malbolge_encode(text: str) -> str:
 def run_python(code: str, env: dict[str, object] | None = None) -> str:
     """Execute *code* using the restricted Apophis Python subset.
 
+    This subset supports variable assignments, ``print`` calls, arithmetic
+    expressions, ``if`` statements and ``while`` loops.  Only a curated
+    selection of Python's AST nodes is permitted to keep the interpreter
+    intentionally small and safe.
+
     Parameters
     ----------
     code:
@@ -100,6 +105,24 @@ def run_python(code: str, env: dict[str, object] | None = None) -> str:
         ast.Div,
         ast.Pow,
         ast.Mod,
+        ast.If,
+        ast.While,
+        ast.Compare,
+        ast.Eq,
+        ast.NotEq,
+        ast.Lt,
+        ast.LtE,
+        ast.Gt,
+        ast.GtE,
+        ast.BoolOp,
+        ast.And,
+        ast.Or,
+        ast.UnaryOp,
+        ast.UAdd,
+        ast.USub,
+        ast.Break,
+        ast.Continue,
+        ast.Pass,
     )
     for node in ast.walk(tree):
         if not isinstance(node, allowed_nodes):

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -37,6 +37,18 @@ def test_run_python_rejects_import():
         apophis.run_python("import os")
 
 
+def test_run_python_if_statement():
+    code = "x = 5\nif x > 3:\n    print('yes')"
+    assert apophis.run_python(code) == "yes\n"
+
+
+def test_run_python_while_loop():
+    code = (
+        "x = 0\n" "while x < 3:\n" "    print(x)\n" "    x = x + 1"
+    )
+    assert apophis.run_python(code) == "0\n1\n2\n"
+
+
 def test_run_apophis_mixed_string():
     code = ":print('A', end='')\n>b\n:print('B', end='')"
     assert apophis.run_apophis(code) == "AsB"


### PR DESCRIPTION
## Summary
- allow basic `if` statements and `while` loops in the Python subset
- document new control flow features
- add tests for `if` and `while`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f6f9f3028832f9814ab5c9005cc53