### PR TITLE
Add Ruby integration to Apophis

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ https://www.researchgate.net/publication/369734814_apophis_syntax
 #ApophisProgrammingLanguage 
 Future usage for the #ApophisMiningFacility and the #ApophisClassUNSCStarfleet #GottaCatchAnAsteroid #ApophisNewMoon #MoonGod #UNSC #starship #AsteroidMining 
 
-Apophis is an (In Development) programming language that combines the syntax of Python and the esoteric programming language Malbolge. (#GitHub Coming Soon)
+Apophis is an (In Development) programming language that combines the syntax of Python, Ruby and the esoteric programming language Malbolge. (#GitHub Coming Soon)
 
 Apophis includes the ability to run Malbolge code using the `run_malbolge(code)`
 function. This takes a Malbolge program as a string argument and returns the
 output.
 
-The language also supports **hybrid programs** that mix Python and Malbolge.  In
-these sources, lines beginning with ``:`` are interpreted as Python while all
-other lines are executed as Malbolge.  The outputs from both languages are
+The language also supports **hybrid programs** that mix Python, Ruby and Malbolge.  In
+these sources, lines beginning with ``:`` are interpreted as Python, lines beginning with ``;``
+are executed as Ruby while all other lines run as Malbolge.  The outputs from all languages are
 concatenated.  Use :func:`apophis.run_apophis` to execute code stored in a
 string and :func:`apophis.run_file` for ``.apop``/``.apo`` files.
 
@@ -20,8 +20,8 @@ Example hybrid program executed from a string:
 ```python
 import apophis
 
-code = ":print('A', end='')\n>b\n:print('B')"
-print(apophis.run_apophis(code))  # -> AsB\n
+code = ":print('A', end='')\n;print 'B'\n>b\n:print('C')"
+print(apophis.run_apophis(code))  # -> ABsC\n
 ```
 
 Hybrid sources can also be saved to ``.apop`` files and run with
@@ -36,8 +36,9 @@ string into Malbolge code using the language's encryption algorithm.
 
 An interpreter for a safe subset of Python is available via
 `run_python(code)`.  It allows variable assignments, arithmetic expressions,
-basic control flow (``if`` statements and ``while`` loops) and ``print`` calls.
-The output of the program is returned as a string:
+basic control flow (``if`` statements and ``while`` loops) and ``print`` calls
+(``puts`` is provided as an alias).  The output of the program is returned as a
+string:
 
 ```python
 import apophis
@@ -46,7 +47,16 @@ result = apophis.run_python("x = 2\nprint(x + 1)")
 assert result == "3\n"
 ```
 
-Overall, Apophis blends the syntax and capabilities of both Python and
+Ruby code can be executed with :func:`run_ruby`, which invokes the system Ruby
+interpreter and returns its stdout:
+
+```python
+import apophis
+
+assert apophis.run_ruby("print 'hi'") == "hi"
+```
+
+Overall, Apophis blends the syntax and capabilities of Python, Ruby and
 Malbolge, allowing for the use of traditional programming concepts alongside
 the challenge and obscurity of Malbolge's encryption algorithm.
 
@@ -60,7 +70,7 @@ pip install apophis
 
 ## Usage
 
-The `apophis` module provides helpers for experimenting with Malbolge:
+The `apophis` module provides helpers for experimenting with Malbolge and Ruby:
 
 ```python
 import apophis

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -32,6 +32,10 @@ def test_run_python_basic():
     assert apophis.run_python(code) == "3\n"
 
 
+def test_run_python_puts_alias():
+    assert apophis.run_python("puts('hello')") == "hello\n"
+
+
 def test_run_python_rejects_import():
     with pytest.raises(ValueError):
         apophis.run_python("import os")
@@ -52,6 +56,15 @@ def test_run_python_while_loop():
 def test_run_apophis_mixed_string():
     code = ":print('A', end='')\n>b\n:print('B', end='')"
     assert apophis.run_apophis(code) == "AsB"
+
+
+def test_run_ruby_basic():
+    assert apophis.run_ruby("print 'hi'") == "hi"
+
+
+def test_run_apophis_with_ruby():
+    code = ":print('A', end='')\n;print 'B'\n:print('C', end='')"
+    assert apophis.run_apophis(code) == "ABC"
 
 
 def test_run_apophis_mixed_file(tmp_path):


### PR DESCRIPTION
## Summary
- add Ruby execution via new `run_ruby` helper
- support Ruby segments (`;`) and `puts` alias in Apophis interpreter and REPL
- document Ruby usage and extend test suite

## Testing
- `pip install malbolge -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f712143b8832fa168486b4f31741a