### PR TITLE
feat: allow ruby-style blocks in python subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ string into Malbolge code using the language's encryption algorithm.
 An interpreter for a safe subset of Python is available via
 `run_python(code)`.  It allows variable assignments, arithmetic expressions,
 basic control flow (``if`` statements and ``while`` loops) and ``print`` calls
-(``puts`` is provided as an alias).  The output of the program is returned as a
-string:
+(``puts`` is provided as an alias).  A tiny Ruby-like syntax is also accepted:
+``if``/``while`` blocks may omit trailing colons and be terminated with
+``end``.  The output of the program is returned as a string:
 
 ```python
 import apophis

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -46,6 +46,11 @@ def test_run_python_if_statement():
     assert apophis.run_python(code) == "yes\n"
 
 
+def test_run_python_ruby_style_block():
+    code = "x = 1\nif x == 1\n    puts('ok')\nend"
+    assert apophis.run_python(code) == "ok\n"
+
+
 def test_run_python_while_loop():
     code = (
         "x = 0\n" "while x < 3:\n" "    print(x)\n" "    x = x + 1"


### PR DESCRIPTION
## Summary
- allow run_python to understand minimal Ruby-like syntax (`end` blocks and missing colons)
- document Ruby-style syntax support
- test Ruby-style block handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f730882f8832f86193af79c29242b