### PR TITLE
Add Ruby-style function support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,21 @@ An interpreter for a safe subset of Python is available via
 `run_python(code)`.  It allows variable assignments, arithmetic expressions,
 basic control flow (``if`` statements and ``while`` loops) and ``print`` calls
 (``puts`` is provided as an alias).  A tiny Ruby-like syntax is also accepted:
-``if``/``while`` blocks may omit trailing colons and be terminated with
-``end``.  The output of the program is returned as a string:
+``if``/``while``/``def`` blocks may omit trailing colons and be terminated
+with ``end``.  The output of the program is returned as a string:
 
 ```python
 import apophis
 
 result = apophis.run_python("x = 2\nprint(x + 1)")
 assert result == "3\n"
+```
+
+Ruby-style function definitions are also understood:
+
+```python
+code = "def add(a, b)\n  return a + b\nend\nputs(add(1, 2))"
+assert apophis.run_python(code) == "3\n"
 ```
 
 Ruby code can be executed with :func:`run_ruby`, which invokes the system Ruby

--- a/apophis.py
+++ b/apophis.py
@@ -89,8 +89,8 @@ def _ruby_to_python(code: str) -> str:
     """Translate a tiny Ruby-like syntax subset into valid Python code.
 
     This helper allows ``run_python`` to accept blocks written using Ruby's
-    ``end`` keyword and missing colons after ``if``/``while`` statements.  The
-    transformation is intentionally minimal and does not aim to be a full
+    ``end`` keyword and missing colons after ``if``/``while``/``def`` statements.
+    The transformation is intentionally minimal and does not aim to be a full
     Ruby-to-Python converter.
     """
 
@@ -100,7 +100,7 @@ def _ruby_to_python(code: str) -> str:
         if stripped == "end":
             continue
         first_word = stripped.split(" ", 1)[0] if stripped else ""
-        if first_word in {"if", "while", "elif", "else"} and not stripped.endswith(":"):
+        if first_word in {"if", "while", "elif", "else", "def"} and not stripped.endswith(":"):
             line = line.rstrip() + ":"
         lines.append(line)
     return "\n".join(lines)
@@ -110,9 +110,10 @@ def run_python(code: str, env: dict[str, object] | None = None) -> str:
     """Execute *code* using the restricted Apophis Python subset.
 
     This subset supports variable assignments, ``print`` calls, arithmetic
-    expressions, ``if`` statements and ``while`` loops.  A minimal Ruby-like
-    syntax is also recognised: ``if``/``while`` blocks may omit the trailing
-    colon and be terminated with ``end``.  Only a curated selection of Python's
+    expressions, ``if`` statements, ``while`` loops and ``def`` function
+    declarations.  A minimal Ruby-like syntax is also recognised:
+    ``if``/``while``/``def`` blocks may omit the trailing colon and be
+    terminated with ``end``.  Only a curated selection of Python's
     AST nodes is permitted to keep the interpreter intentionally small and safe.
 
     Parameters
@@ -133,6 +134,10 @@ def run_python(code: str, env: dict[str, object] | None = None) -> str:
         ast.Assign,
         ast.Expr,
         ast.Call,
+        ast.FunctionDef,
+        ast.arguments,
+        ast.arg,
+        ast.Return,
         ast.Name,
         ast.Load,
         ast.Store,

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -58,6 +58,11 @@ def test_run_python_while_loop():
     assert apophis.run_python(code) == "0\n1\n2\n"
 
 
+def test_run_python_ruby_style_function():
+    code = "def add(a, b)\n    return a + b\nend\nputs(add(1, 2))"
+    assert apophis.run_python(code) == "3\n"
+
+
 def test_run_apophis_mixed_string():
     code = ":print('A', end='')\n>b\n:print('B', end='')"
     assert apophis.run_apophis(code) == "AsB"


### PR DESCRIPTION
## Summary
- allow `def ... end` blocks in the Ruby-friendly subset of `run_python`
- document and test Ruby-style function definitions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f80f52308832faee05b796b67bee8