### PR TITLE
feat: share state with Ruby and support Ruby-style defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ output.
 The language also supports **hybrid programs** that mix Python, Ruby and Malbolge.  In
 these sources, lines beginning with ``:`` are interpreted as Python, lines beginning with ``;``
 are executed as Ruby while all other lines run as Malbolge.  The outputs from all languages are
-concatenated.  Use :func:`apophis.run_apophis` to execute code stored in a
-string and :func:`apophis.run_file` for ``.apop``/``.apo`` files.
+concatenated and variables defined in Python or Ruby segments persist across subsequent
+segments.  Use :func:`apophis.run_apophis` to execute code stored in a string and
+:func:`apophis.run_file` for ``.apop``/``.apo`` files.
 
 Example hybrid program executed from a string:
 
@@ -36,10 +37,10 @@ string into Malbolge code using the language's encryption algorithm.
 
 An interpreter for a safe subset of Python is available via
 `run_python(code)`.  It allows variable assignments, arithmetic expressions,
-basic control flow (``if`` statements and ``while`` loops) and ``print`` calls
-(``puts`` is provided as an alias).  A tiny Ruby-like syntax is also accepted:
-``if``/``while`` blocks may omit trailing colons and be terminated with
-``end``.  The output of the program is returned as a string:
+basic control flow (``if`` statements, ``while`` loops and ``def`` blocks) and
+``print`` calls (``puts`` is provided as an alias).  A tiny Ruby-like syntax is
+also accepted: ``if``/``while``/``def`` blocks may omit trailing colons and be
+terminated with ``end``.  The output of the program is returned as a string:
 
 ```python
 import apophis
@@ -49,7 +50,8 @@ assert result == "3\n"
 ```
 
 Ruby code can be executed with :func:`run_ruby`, which invokes the system Ruby
-interpreter and returns its stdout:
+interpreter and returns its stdout.  A mapping can be provided to share
+variables with Python code:
 
 ```python
 import apophis

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -104,3 +104,13 @@ def test_repl_persistence():
 
     apophis.repl(input_func=fake_input, output_func=fake_output)
     assert "".join(outputs) == "2\n"
+
+
+def test_run_python_ruby_style_function():
+    code = "def add(x, y)\n    return x + y\nend\nprint(add(2, 3))"
+    assert apophis.run_python(code) == "5\n"
+
+
+def test_run_apophis_cross_language_env():
+    code = ":x = 5\n;puts x\n;y = x + 1\n:print(y)"
+    assert apophis.run_apophis(code) == "5\n6\n"


### PR DESCRIPTION
## Summary
- allow Ruby and Python segments to share variables via a common environment
- accept Ruby-style `def … end` function blocks in the Python subset
- document hybrid variable persistence and function support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f80f52308832faee05b796b67bee8