### PR TITLE
Expand Ruby-style syntax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ An interpreter for a safe subset of Python is available via
 basic control flow (``if`` statements, ``while`` loops and ``def`` blocks) and
 ``print`` calls (``puts`` is provided as an alias).  A tiny Ruby-like syntax is
 also accepted: ``if``/``while``/``def`` blocks may omit trailing colons and be
-terminated with ``end``.  The output of the program is returned as a string:
+terminated with ``end``; ``elsif``, ``unless`` and ``until`` are also
+understood.  The output of the program is returned as a string:
 
 ```python
 import apophis

--- a/apophis.py
+++ b/apophis.py
@@ -127,6 +127,16 @@ def _ruby_to_python(code: str) -> str:
         if stripped == "end":
             continue
         first_word = stripped.split(" ", 1)[0] if stripped else ""
+        if first_word == "elsif":
+            line = line.replace("elsif", "elif", 1)
+            first_word = "elif"
+        elif first_word == "unless":
+            line = line.replace("unless", "if not", 1)
+            first_word = "if"
+        elif first_word == "until":
+            line = line.replace("until", "while not", 1)
+            first_word = "while"
+        stripped = line.strip()
         if first_word in {"if", "while", "elif", "else", "def"} and not stripped.endswith(":"):
             line = line.rstrip() + ":"
         lines.append(line)
@@ -139,9 +149,10 @@ def run_python(code: str, env: dict[str, object] | None = None) -> str:
     This subset supports variable assignments, ``print`` calls, arithmetic
     expressions, ``if`` statements, ``while`` loops and function definitions.  A
     minimal Ruby-like syntax is also recognised: ``if``/``while``/``def`` blocks
-    may omit the trailing colon and be terminated with ``end``.  Only a curated
-    selection of Python's AST nodes is permitted to keep the interpreter
-    intentionally small and safe.
+    may omit the trailing colon and be terminated with ``end``; ``elsif``,
+    ``unless`` and ``until`` are accepted as aliases for ``elif``, ``if not`` and
+    ``while not`` respectively.  Only a curated selection of Python's AST nodes
+    is permitted to keep the interpreter intentionally small and safe.
 
     Parameters
     ----------
@@ -192,6 +203,7 @@ def run_python(code: str, env: dict[str, object] | None = None) -> str:
         ast.UnaryOp,
         ast.UAdd,
         ast.USub,
+        ast.Not,
         ast.Break,
         ast.Continue,
         ast.Pass,

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -111,6 +111,32 @@ def test_run_python_ruby_style_function():
     assert apophis.run_python(code) == "5\n"
 
 
+def test_run_python_ruby_style_elsif():
+    code = (
+        "x = 2\n"
+        "if x == 1\n"
+        "    puts('one')\n"
+        "elsif x == 2\n"
+        "    puts('two')\n"
+        "end"
+    )
+    assert apophis.run_python(code) == "two\n"
+
+
+def test_run_python_ruby_style_unless_until():
+    code_unless = "x = 1\nunless x > 1\n    puts('ok')\nend"
+    assert apophis.run_python(code_unless) == "ok\n"
+
+    code_until = (
+        "x = 0\n"
+        "until x == 2\n"
+        "    puts(x)\n"
+        "    x = x + 1\n"
+        "end"
+    )
+    assert apophis.run_python(code_until) == "0\n1\n"
+
+
 def test_run_apophis_cross_language_env():
     code = ":x = 5\n;puts x\n;y = x + 1\n:print(y)"
     assert apophis.run_apophis(code) == "5\n6\n"


### PR DESCRIPTION
## Summary
- expand `_ruby_to_python` with `elsif`, `unless`, and `until`
- allow unary `not` and document the new Ruby-like keywords
- test Ruby-style control flow variants

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9e08bd68832f91ae0c83a4984d2f