### PR TITLE
Expand Ruby-style features and cross-language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ string into Malbolge code using the language's encryption algorithm.
 
 An interpreter for a safe subset of Python is available via
 `run_python(code)`.  It allows variable assignments, arithmetic expressions,
-basic control flow (``if`` statements, ``while`` loops and ``def`` blocks) and
+basic control flow (``if``/``while``/``for`` loops and ``def`` blocks) and
 ``print`` calls (``puts`` is provided as an alias).  A tiny Ruby-like syntax is
-also accepted: ``if``/``while``/``def`` blocks may omit trailing colons and be
-terminated with ``end``; ``elsif``, ``unless`` and ``until`` are also
-understood.  The output of the program is returned as a string:
+also accepted: ``if``/``while``/``for``/``def`` blocks may omit trailing colons,
+optionally include ``do`` or ``then`` and be terminated with ``end``;
+``elsif``, ``unless``, ``until`` and ``next`` are also understood.  Ruby code can
+be executed inline from Python using a ``ruby()`` helper which shares
+variables between languages.  The output of the program is returned as a
+string:
 
 ```python
 import apophis

--- a/test_apophis.py
+++ b/test_apophis.py
@@ -137,6 +137,31 @@ def test_run_python_ruby_style_unless_until():
     assert apophis.run_python(code_until) == "0\n1\n"
 
 
+def test_run_python_ruby_style_for_and_next():
+    code = (
+        "for i in range(3) do\n"
+        "    if i == 1\n"
+        "        next\n"
+        "    end\n"
+        "    puts(i)\n"
+        "end"
+    )
+    assert apophis.run_python(code) == "0\n2\n"
+
+
+def test_run_python_inline_ruby():
+    code = (
+        "x = 1\n"
+        "ruby(\"x = x + 1\")\n"
+        "print(x)\n"
+    )
+    assert apophis.run_python(code) == "2\n"
+
+
+def test_run_python_ruby_output():
+    assert apophis.run_python("ruby(\"puts 'hi'\")") == "hi\n"
+
+
 def test_run_apophis_cross_language_env():
     code = ":x = 5\n;puts x\n;y = x + 1\n:print(y)"
     assert apophis.run_apophis(code) == "5\n6\n"


### PR DESCRIPTION
## Summary
- Broaden `_ruby_to_python` translation with `for` loops, `do`/`then`, and `next` alias for `continue`.
- Extend Python subset to include `for` loops and provide a `ruby()` helper plus `range` for cross-language interaction.
- Document Ruby-like syntax and inline Ruby execution in README and add tests for new language features.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689018f1bb98832f85b51252362c09d4