### PR TITLE
feat: enhance desktop IDE with output console and save prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ apophis -i
 
 A minimal Tkinter based desktop IDE is bundled with the project.  It can be
 started from Python and provides basic open/save/run capabilities for Apophis
-programs.  Standard editing shortcuts (new, undo/redo, cut/copy/paste) and a
-status bar showing the cursor location make it a bit more pleasant for day to
-day use:
+programs.  Standard editing shortcuts (new, undo/redo, cut/copy/paste), a
+persistent output console and prompts to save unsaved changes with a status bar
+showing the cursor location make it a bit more pleasant for day to day use:
 
 ```python
 import apophis_ide

--- a/test_apophis_ide.py
+++ b/test_apophis_ide.py
@@ -15,6 +15,9 @@ def test_class_methods():
         'run_code',
         'undo',
         'redo',
+        'clear_output',
+        'maybe_save',
+        'on_close',
         'update_status_bar',
     }
     for name in required:


### PR DESCRIPTION
## Summary
- add scrollable output console to Apophis IDE with clear command and key binding
- warn about unsaved changes and update window title accordingly
- document new features and ensure IDE exposes new helper methods

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689182caefc4832fbc07d55df1cb09dd