### PR TITLE
Add find/replace functionality to Apophis IDE

### DIFF
--- a/test_apophis_ide.py
+++ b/test_apophis_ide.py
@@ -15,6 +15,8 @@ def test_class_methods():
         'run_code',
         'undo',
         'redo',
+        'find_text',
+        'replace_text',
         'clear_output',
         'maybe_save',
         'on_close',


### PR DESCRIPTION
## Summary
- extend the Apophis IDE with find and replace editing commands
- bind keyboard shortcuts and menu entries for find (Ctrl+F) and replace (Ctrl+H)
- test for presence of new editing methods

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68918909d794832fa55bccb4f225b3fd