### PR TITLE
Add packaging tutorial example project

### DIFF
--- a/packaging_tutorial/LICENSE
+++ b/packaging_tutorial/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018 The Python Packaging Authority
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packaging_tutorial/README.md
+++ b/packaging_tutorial/README.md
@@ -1,0 +1,3 @@
+# Example Package
+
+This is a simple example package. You can use [GitHub-flavored Markdown](https://guides.github.com/features/mastering-markdown/) to write your content.

--- a/packaging_tutorial/pyproject.toml
+++ b/packaging_tutorial/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "example_package_djlacavera21"
+version = "0.0.1"
+authors = [
+  { name="Example Author", email="author@example.com" },
+]
+description = "A small example package"
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+license = "MIT"
+license-files = ["LICEN[CS]E*"]
+
+[project.urls]
+Homepage = "https://github.com/pypa/sampleproject"
+Issues = "https://github.com/pypa/sampleproject/issues"

--- a/packaging_tutorial/src/example_package_djlacavera21/__init__.py
+++ b/packaging_tutorial/src/example_package_djlacavera21/__init__.py
@@ -1,0 +1,1 @@
+# Example package __init__

--- a/packaging_tutorial/src/example_package_djlacavera21/example.py
+++ b/packaging_tutorial/src/example_package_djlacavera21/example.py
@@ -1,0 +1,2 @@
+def add_one(number):
+    return number + 1


### PR DESCRIPTION
## Summary
- add packaging_tutorial sample project with metadata and simple module
- include MIT license and README for example package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891911ed1c8832f830bd62761cd6bb7