### PR TITLE
Add desktop menu entry to Debian package

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,6 @@ build a `.deb` package containing the Apophis modules and desktop IDE.  Run:
 The resulting `apophis_<version>.deb` can then be installed with
 `dpkg -i`.
 
+After installation a desktop menu entry titled **Apophis** will be
+available for launching the IDE.
+

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -15,7 +15,10 @@ PY
 WORKDIR=build/deb
 
 rm -rf "$WORKDIR" "${NAME}_${VERSION}.deb"
-mkdir -p "$WORKDIR/DEBIAN" "$WORKDIR/usr/lib/python3/dist-packages" "$WORKDIR/usr/bin"
+mkdir -p "$WORKDIR/DEBIAN" \
+         "$WORKDIR/usr/lib/python3/dist-packages" \
+         "$WORKDIR/usr/bin" \
+         "$WORKDIR/usr/share/applications"
 
 cat > "$WORKDIR/DEBIAN/control" <<CONTROL
 Package: $NAME
@@ -38,6 +41,18 @@ from apophis_ide import launch
 launch()
 LAUNCH
 chmod +x "$WORKDIR/usr/bin/apophis-ide"
+
+# Desktop entry for menu systems
+cat > "$WORKDIR/usr/share/applications/apophis.desktop" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=Apophis
+Comment=Apophis IDE
+Exec=apophis-ide
+Terminal=false
+Categories=Development;
+DESKTOP
+chmod 644 "$WORKDIR/usr/share/applications/apophis.desktop"
 
 dpkg-deb --build "$WORKDIR" "${NAME}_${VERSION}.deb"
 


### PR DESCRIPTION
## Summary
- create .desktop menu entry when building the Debian package so the IDE appears as "Apophis" in system menus
- document the installed menu shortcut in the README

## Testing
- `pytest`
- `./build_deb.sh`
- `dpkg-deb -c apophis_0.1.0.deb | grep -E 'apophis.desktop|usr/share/applications'`


------
https://chatgpt.com/codex/tasks/task_e_6891995c8938832fa264a127cb51b920