### PR TITLE
chore: expose public API

### DIFF
--- a/apophis.py
+++ b/apophis.py
@@ -18,6 +18,20 @@ import subprocess
 import malbolge
 
 
+# Explicit re-exports for the public API.  This helps tools and users relying
+# on introspection discover the main entry points of the library.
+__all__ = [
+    "run_malbolge",
+    "run_file",
+    "malbolge_encode",
+    "run_ruby",
+    "run_python",
+    "run_apophis",
+    "repl",
+    "main",
+]
+
+
 def run_malbolge(code: str) -> str:
     """Execute *code* written in Malbolge and return its output.
 


### PR DESCRIPTION
## Summary
- explicitly export the library's public API, including `run_apophis`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68919c137b54832fb257282a59a7d56d